### PR TITLE
Way to much cpu load because of background panning in default Mint-X html theme

### DIFF
--- a/usr/share/mdm/html-themes/Mint-X/index.html
+++ b/usr/share/mdm/html-themes/Mint-X/index.html
@@ -480,23 +480,22 @@
  	});   	
 
 	// Panning
-	panning = new Motio(document.getElementById('background'), {
-		fps: 30,
-		speedY: 30
-		
-	});
+	//panning = new Motio(document.getElementById('background'), {
+	//	fps: 30,
+	//	speedY: 30
+	//});
 
-	function moveDiv(){
-        var speed = Math.floor((Math.random()*3)+1);
-        speed = speed -2;
-        speed = speed * 30;
-        //panning.set('speedX', speed);                 
-    };
+	//function moveDiv(){
+	//var speed = Math.floor((Math.random()*3)+1);
+	//speed = speed -2;
+	//speed = speed * 30;
+	//panning.set('speedX', speed);
+	//};
 
-	panning.play(); // Start playing animation
+	//panning.play(); // Start playing animation
 
-	moveDiv();
-	setInterval(moveDiv, 10000);
+	//moveDiv();
+	//setInterval(moveDiv, 10000);
 
 	// $(document).ready(function() {
 	// 	document.getElementById("entry").focus();


### PR DESCRIPTION
Please remove the background panning in Mint-X theme, because it eats up loads of cpu.

On my machine cpu usage goes up to 100% with the propietary AMD Catalyst driver (for Radeon HD6870) and around 20% with the newest mesa git and kernel 3.12. With the propietary driver the login screen even gets unresponsive when selecting the user and typing the password.
