### PR TITLE
Fixed hostname display in Elegance theme

### DIFF
--- a/usr/share/mdm/themes/Elegance/theme.xml
+++ b/usr/share/mdm/themes/Elegance/theme.xml
@@ -21,9 +21,10 @@
     <text>%c</text>
   </item>
   
+  <!-- the hostname on topleft -->
   <item type="label">
     <normal color="#ffffff" font="Sans 12" alpha="0.8"/>
-    <pos x="59" y="22" anchor="e"/>
+    <pos x="20" y="22" anchor="w"/>
     <text>%h</text>
   </item>
   


### PR DESCRIPTION
The hostname in the Elegance theme was displayed on the top left, but with right alignment. So hostnames longer than 4-5 letters were cut off. This is fixed here.
