### PR TITLE
Use flags of minority languages

### DIFF
--- a/mint-mdm-themes-html/usr/share/mdm/html-themes/BlimpCity/index.html
+++ b/mint-mdm-themes-html/usr/share/mdm/html-themes/BlimpCity/index.html
@@ -200,7 +200,7 @@
 			var li = document.createElement('li');			
 				
 			var link = document.createElement('a');	
-				link.setAttribute('href', "javascript:alert('LANGUAGE###"+language_code+"')");
+				link.setAttribute('href', "javascript:alert('LANGUAGE###"+language_code+"');mdm_set_current_language('"+language_name+"','"+language_code+"');");
 
 			var picture = document.createElement('img');
 				picture.setAttribute('class', "language-picture");

--- a/mint-mdm-themes-html/usr/share/mdm/html-themes/BlimpCity/index.html
+++ b/mint-mdm-themes-html/usr/share/mdm/html-themes/BlimpCity/index.html
@@ -166,16 +166,37 @@
 			document.getElementById("current_session_picture").src = "../common/img/sessions/"+filename+".svg";
 			document.getElementById("current_session_picture").title = session_name;
 		}
-
-		// Called by MDM to add a language to the list of languages
-		function mdm_add_language(language_name, language_code) {
-
+		
+		// Called by MDM to get the full path of a language flag file
+		function mdm_get_language_flag_filepath(language_code) {
 			var filename = language_code.toLowerCase();
 			filename = filename.replace(".utf-8", "");
-			bits = filename.split("_");
-			if (bits.length == 2) {
-				filename = bits[1];																	
+			var bits = filename.split("_");
+
+			// Check for minority languages that have a flag.
+			// For example: Catalan's language code can be ca or ca_es or ca_fr, Welsh's cy or cy_gb...
+			if (filename === "ca" || bits[0] === "ca") {
+				filename = "_Catalonia";
+			} else if (filename === "cy" || bits[0] === "cy") {
+				filename = "_Wales";
+			} else if (filename === "eu" || bits[0] === "eu") {
+				filename = "_Basque Country";
+			} else if (filename === "gd" || bits[0] === "gd") {
+				filename = "_Scotland";
+			} else if (filename === "gl" || bits[0] === "gl") {
+				filename = "_Galicia";
+			} else if (filename === "sco" || bits[0] === "sco") {
+				filename = "_Scotland";
+			// Use the country code part of the language code (if it's available). For example: en_AU -> au.
+			} else if (bits.length === 2) {
+				filename = bits[1];
 			}
+
+			return "../common/img/languages/"+filename+".png";
+		}
+		
+		// Called by MDM to add a language to the list of languages
+		function mdm_add_language(language_name, language_code) {
 			var li = document.createElement('li');			
 				
 			var link = document.createElement('a');	
@@ -183,7 +204,7 @@
 
 			var picture = document.createElement('img');
 				picture.setAttribute('class', "language-picture");
-				picture.setAttribute('src', "../common/img/languages/"+filename+".png");
+				picture.setAttribute('src', mdm_get_language_flag_filepath(language_code));
 				picture.setAttribute('onerror', "this.src='../common/img/languages/generic.png';");
 											
 			var name_div = document.createTextNode(language_name);				
@@ -197,13 +218,7 @@
 		}	
 
 		function mdm_set_current_language(language_name, language_code)	{
-			var filename = language_code.toLowerCase();
-			filename = filename.replace(".utf-8", "");
-			bits = filename.split("_");
-			if (bits.length == 2) {
-				filename = bits[1];																	
-			}
-			document.getElementById("current_language_flag").src = "../common/img/languages/"+filename+".png";			
+			document.getElementById("current_language_flag").src = mdm_get_language_flag_filepath(language_code);			
 			document.getElementById("current_language_flag").title = language_name;
 		}
 		

--- a/mint-mdm-themes-html/usr/share/mdm/html-themes/Clouds/index.html
+++ b/mint-mdm-themes-html/usr/share/mdm/html-themes/Clouds/index.html
@@ -220,17 +220,38 @@
             var cell2 = row.insertCell(1);           
             cell2.appendChild(link2);
 		}			
-
-		// Called by MDM to add a language to the list of languages
-		function mdm_add_language(language_name, language_code) {
-
+		
+				
+		// Called by MDM to get the full path of a language flag file
+		function mdm_get_language_flag_filepath(language_code) {
 			var filename = language_code.toLowerCase();
 			filename = filename.replace(".utf-8", "");
-			bits = filename.split("_");
-			if (bits.length == 2) {
-				filename = bits[1];																	
-			}			
-				
+			var bits = filename.split("_");
+
+			// Check for minority languages that have a flag.
+			// For example: Catalan's language code can be ca or ca_es or ca_fr, Welsh's cy or cy_gb...
+			if (filename === "ca" || bits[0] === "ca") {
+				filename = "_Catalonia";
+			} else if (filename === "cy" || bits[0] === "cy") {
+				filename = "_Wales";
+			} else if (filename === "eu" || bits[0] === "eu") {
+				filename = "_Basque Country";
+			} else if (filename === "gd" || bits[0] === "gd") {
+				filename = "_Scotland";
+			} else if (filename === "gl" || bits[0] === "gl") {
+				filename = "_Galicia";
+			} else if (filename === "sco" || bits[0] === "sco") {
+				filename = "_Scotland";
+			// Use the country code part of the language code (if it's available). For example: en_AU -> au.
+			} else if (bits.length === 2) {
+				filename = bits[1];
+			}
+
+			return "../common/img/languages/"+filename+".png";
+		}
+		
+		// Called by MDM to add a language to the list of languages
+		function mdm_add_language(language_name, language_code) {		
 			var link1 = document.createElement('a');	
 				link1.setAttribute('href', "javascript:alert('LANGUAGE###"+language_code+"');mdm_set_current_language('"+language_name+"','"+language_code+"');");
 
@@ -239,7 +260,7 @@
 
 			var picture = document.createElement('img');
 				picture.setAttribute('class', "language-picture");
-				picture.setAttribute('src', "../common/img/languages/"+filename+".png");
+				picture.setAttribute('src', mdm_get_language_flag_filepath(language_code));
 				picture.setAttribute('onerror', "this.src='../common/img/languages/generic.png';");
 				picture.setAttribute('title', language_name);				
 											
@@ -261,15 +282,9 @@
             cell2.appendChild(link2);
 
 		}	
-
+		
 		function mdm_set_current_language(language_name, language_code)	{
-			var filename = language_code.toLowerCase();
-			filename = filename.replace(".utf-8", "");
-			bits = filename.split("_");
-			if (bits.length == 2) {
-				filename = bits[1];																	
-			}
-			document.getElementById("current_language_flag").src = "../common/img/languages/"+filename+".png";
+			document.getElementById("current_language_flag").src = mdm_get_language_flag_filepath(language_code);
 			document.getElementById("current_language_flag").title = language_name;
 			document.getElementById("current_language_flag").width = 16;
 			$('#languageSelection').modal('hide');

--- a/mint-mdm-themes-html/usr/share/mdm/html-themes/FullMoon/index.html
+++ b/mint-mdm-themes-html/usr/share/mdm/html-themes/FullMoon/index.html
@@ -200,7 +200,7 @@
 			var li = document.createElement('li');			
 				
 			var link = document.createElement('a');	
-				link.setAttribute('href', "javascript:alert('LANGUAGE###"+language_code+"')");
+				link.setAttribute('href', "javascript:alert('LANGUAGE###"+language_code+"');mdm_set_current_language('"+language_name+"','"+language_code+"');");
 
 			var picture = document.createElement('img');
 				picture.setAttribute('class', "language-picture");

--- a/mint-mdm-themes-html/usr/share/mdm/html-themes/FullMoon/index.html
+++ b/mint-mdm-themes-html/usr/share/mdm/html-themes/FullMoon/index.html
@@ -166,16 +166,37 @@
 			document.getElementById("current_session_picture").src = "../common/img/sessions/"+filename+".svg";
 			document.getElementById("current_session_picture").title = session_name;
 		}
-
-		// Called by MDM to add a language to the list of languages
-		function mdm_add_language(language_name, language_code) {
-
+				
+		// Called by MDM to get the full path of a language flag file
+		function mdm_get_language_flag_filepath(language_code) {
 			var filename = language_code.toLowerCase();
 			filename = filename.replace(".utf-8", "");
-			bits = filename.split("_");
-			if (bits.length == 2) {
-				filename = bits[1];																	
+			var bits = filename.split("_");
+
+			// Check for minority languages that have a flag.
+			// For example: Catalan's language code can be ca or ca_es or ca_fr, Welsh's cy or cy_gb...
+			if (filename === "ca" || bits[0] === "ca") {
+				filename = "_Catalonia";
+			} else if (filename === "cy" || bits[0] === "cy") {
+				filename = "_Wales";
+			} else if (filename === "eu" || bits[0] === "eu") {
+				filename = "_Basque Country";
+			} else if (filename === "gd" || bits[0] === "gd") {
+				filename = "_Scotland";
+			} else if (filename === "gl" || bits[0] === "gl") {
+				filename = "_Galicia";
+			} else if (filename === "sco" || bits[0] === "sco") {
+				filename = "_Scotland";
+			// Use the country code part of the language code (if it's available). For example: en_AU -> au.
+			} else if (bits.length === 2) {
+				filename = bits[1];
 			}
+
+			return "../common/img/languages/"+filename+".png";
+		}
+		
+		// Called by MDM to add a language to the list of languages
+		function mdm_add_language(language_name, language_code) {
 			var li = document.createElement('li');			
 				
 			var link = document.createElement('a');	
@@ -183,7 +204,7 @@
 
 			var picture = document.createElement('img');
 				picture.setAttribute('class', "language-picture");
-				picture.setAttribute('src', "../common/img/languages/"+filename+".png");
+				picture.setAttribute('src', mdm_get_language_flag_filepath(language_code));
 				picture.setAttribute('onerror', "this.src='../common/img/languages/generic.png';");
 											
 			var name_div = document.createTextNode(language_name);				
@@ -197,13 +218,7 @@
 		}	
 
 		function mdm_set_current_language(language_name, language_code)	{
-			var filename = language_code.toLowerCase();
-			filename = filename.replace(".utf-8", "");
-			bits = filename.split("_");
-			if (bits.length == 2) {
-				filename = bits[1];																	
-			}
-			document.getElementById("current_language_flag").src = "../common/img/languages/"+filename+".png";			
+			document.getElementById("current_language_flag").src = mdm_get_language_flag_filepath(language_code);			
 			document.getElementById("current_language_flag").title = language_name;
 		}
 		

--- a/mint-mdm-themes-html/usr/share/mdm/html-themes/Mint-X/mdm.js
+++ b/mint-mdm-themes-html/usr/share/mdm/html-themes/Mint-X/mdm.js
@@ -152,18 +152,40 @@ function mdm_add_session(session_name, session_file) {
   
     var cell2 = row.insertCell(1);           
     cell2.appendChild(link2);
-}       
+}       		
+
+// Called by MDM to get the full path of a language flag file
+function mdm_get_language_flag_filepath(language_code) {
+	
+	var filename = language_code.toLowerCase();
+	filename = filename.replace(".utf-8", "");
+	var bits = filename.split("_");
+
+	// Check for minority languages that have a flag.
+	// For example: Catalan's language code can be ca or ca_es or ca_fr, Welsh's cy or cy_gb...
+	if (filename === "ca" || bits[0] === "ca") {
+		filename = "_Catalonia";
+	} else if (filename === "cy" || bits[0] === "cy") {
+		filename = "_Wales";
+	} else if (filename === "eu" || bits[0] === "eu") {
+		filename = "_Basque Country";
+	} else if (filename === "gd" || bits[0] === "gd") {
+		filename = "_Scotland";
+	} else if (filename === "gl" || bits[0] === "gl") {
+		filename = "_Galicia";
+	} else if (filename === "sco" || bits[0] === "sco") {
+		filename = "_Scotland";
+	// Use the country code part of the language code (if it's available). For example: en_AU -> au.
+	} else if (bits.length === 2) {
+		filename = bits[1];
+	}
+
+	return "../common/img/languages/"+filename+".png";
+}
 
 // Called by MDM to add a language to the list of languages
 function mdm_add_language(language_name, language_code) {
-
-    var filename = language_code.toLowerCase();
-    filename = filename.replace(".utf-8", "");
-    bits = filename.split("_");
-    if (bits.length == 2) {
-        filename = bits[1];
-    }
-
+	
     var link1 = document.createElement('a');    
         link1.setAttribute('href', "javascript:alert('LANGUAGE###"+language_code+"');mdm_set_current_language('"+language_name+"','"+language_code+"');");
 
@@ -172,7 +194,7 @@ function mdm_add_language(language_name, language_code) {
 
     var picture = document.createElement('img');
         picture.setAttribute('class', "language-picture");
-        picture.setAttribute('src', "../common/img/languages/"+filename+".png");
+        picture.setAttribute('src', mdm_get_language_flag_filepath(language_code));
         picture.setAttribute('onerror', "this.src='../common/img/languages/generic.png';");
         picture.setAttribute('title', language_name);               
                                     
@@ -195,13 +217,7 @@ function mdm_add_language(language_name, language_code) {
 }
 
 function mdm_set_current_language(language_name, language_code) {
-    var filename = language_code.toLowerCase();
-    filename = filename.replace(".utf-8", "");
-    bits = filename.split("_");
-    if (bits.length == 2) {
-        filename = bits[1];
-    }
-    document.getElementById("current_language_flag").src = "../common/img/languages/"+filename+".png";
+    document.getElementById("current_language_flag").src = mdm_get_language_flag_filepath(language_code);
     document.getElementById("current_language_flag").title = language_name;
     document.getElementById("current_language_flag").width = 16;
     $('#current_language_flag').popover('hide');

--- a/mint-mdm-themes-html/usr/share/mdm/html-themes/Numix/index.html
+++ b/mint-mdm-themes-html/usr/share/mdm/html-themes/Numix/index.html
@@ -208,15 +208,37 @@
 			$('#current_session_picture').popover('hide');
 		}
 
-		// Called by MDM to add a language to the list of languages
-		function mdm_add_language(language_name, language_code) {
-
+		
+		// Called by MDM to get the full path of a language flag file
+		function mdm_get_language_flag_filepath(language_code) {
 			var filename = language_code.toLowerCase();
 			filename = filename.replace(".utf-8", "");
-			bits = filename.split("_");
-			if (bits.length == 2) {
+			var bits = filename.split("_");
+
+			// Check for minority languages that have a flag.
+			// For example: Catalan's language code can be ca or ca_es or ca_fr, Welsh's cy or cy_gb...
+			if (filename === "ca" || bits[0] === "ca") {
+				filename = "_Catalonia";
+			} else if (filename === "cy" || bits[0] === "cy") {
+				filename = "_Wales";
+			} else if (filename === "eu" || bits[0] === "eu") {
+				filename = "_Basque Country";
+			} else if (filename === "gd" || bits[0] === "gd") {
+				filename = "_Scotland";
+			} else if (filename === "gl" || bits[0] === "gl") {
+				filename = "_Galicia";
+			} else if (filename === "sco" || bits[0] === "sco") {
+				filename = "_Scotland";
+			// Use the country code part of the language code (if it's available). For example: en_AU -> au.
+			} else if (bits.length === 2) {
 				filename = bits[1];
 			}
+
+			return "../common/img/languages/"+filename+".png";
+		}
+
+		// Called by MDM to add a language to the list of languages
+		function mdm_add_language(language_name, language_code) {
 
 			var link1 = document.createElement('a');	
 				link1.setAttribute('href', "javascript:alert('LANGUAGE###"+language_code+"')");
@@ -226,7 +248,7 @@
 
 			var picture = document.createElement('img');
 				picture.setAttribute('class', "language-picture");
-				picture.setAttribute('src', "../common/img/languages/"+filename+".png");
+				picture.setAttribute('src', mdm_get_language_flag_filepath(language_code));
 				picture.setAttribute('onerror', "this.src='../common/img/languages/generic.png';");
 				picture.setAttribute('title', language_name);				
 											
@@ -249,13 +271,7 @@
 		}
 
 		function mdm_set_current_language(language_name, language_code)	{
-			var filename = language_code.toLowerCase();
-			filename = filename.replace(".utf-8", "");
-			bits = filename.split("_");
-			if (bits.length == 2) {
-				filename = bits[1];
-			}
-			document.getElementById("current_language_flag").src = "img/language.svg";
+			document.getElementById("current_language_flag").src = mdm_get_language_flag_filepath(language_code);
 			document.getElementById("current_language_flag").title = language_name;
 			document.getElementById("current_language_flag").width = 16;
 		}

--- a/mint-mdm-themes-html/usr/share/mdm/html-themes/Numix/index.html
+++ b/mint-mdm-themes-html/usr/share/mdm/html-themes/Numix/index.html
@@ -241,10 +241,10 @@
 		function mdm_add_language(language_name, language_code) {
 
 			var link1 = document.createElement('a');	
-				link1.setAttribute('href', "javascript:alert('LANGUAGE###"+language_code+"')");
+				link1.setAttribute('href', "javascript:alert('LANGUAGE###"+language_code+"');mdm_set_current_language('"+language_name+"','"+language_code+"');");
 
 			var link2 = document.createElement('a');	
-				link2.setAttribute('href', "javascript:alert('LANGUAGE###"+language_code+"')");
+				link2.setAttribute('href', "javascript:alert('LANGUAGE###"+language_code+"');mdm_set_current_language('"+language_name+"','"+language_code+"');");
 
 			var picture = document.createElement('img');
 				picture.setAttribute('class', "language-picture");

--- a/mint-mdm-themes-html/usr/share/mdm/html-themes/SpaceRace/index.html
+++ b/mint-mdm-themes-html/usr/share/mdm/html-themes/SpaceRace/index.html
@@ -200,7 +200,7 @@
 			var li = document.createElement('li');			
 				
 			var link = document.createElement('a');	
-				link.setAttribute('href', "javascript:alert('LANGUAGE###"+language_code+"')");
+				link.setAttribute('href', "javascript:alert('LANGUAGE###"+language_code+"');mdm_set_current_language('"+language_name+"','"+language_code+"');");
 
 			var picture = document.createElement('img');
 				picture.setAttribute('class', "language-picture");

--- a/mint-mdm-themes-html/usr/share/mdm/html-themes/SpaceRace/index.html
+++ b/mint-mdm-themes-html/usr/share/mdm/html-themes/SpaceRace/index.html
@@ -165,16 +165,38 @@
 			document.getElementById("current_session_picture").src = "../common/img/sessions/"+filename+".svg";
 			document.getElementById("current_session_picture").title = session_name;
 		}
+		
+		// Called by MDM to get the full path of a language flag file
+		function mdm_get_language_flag_filepath(language_code) {
+			var filename = language_code.toLowerCase();
+			filename = filename.replace(".utf-8", "");
+			var bits = filename.split("_");
+
+			// Check for minority languages that have a flag.
+			// For example: Catalan's language code can be ca or ca_es or ca_fr, Welsh's cy or cy_gb...
+			if (filename === "ca" || bits[0] === "ca") {
+				filename = "_Catalonia";
+			} else if (filename === "cy" || bits[0] === "cy") {
+				filename = "_Wales";
+			} else if (filename === "eu" || bits[0] === "eu") {
+				filename = "_Basque Country";
+			} else if (filename === "gd" || bits[0] === "gd") {
+				filename = "_Scotland";
+			} else if (filename === "gl" || bits[0] === "gl") {
+				filename = "_Galicia";
+			} else if (filename === "sco" || bits[0] === "sco") {
+				filename = "_Scotland";
+			// Use the country code part of the language code (if it's available). For example: en_AU -> au.
+			} else if (bits.length === 2) {
+				filename = bits[1];
+			}
+
+			return "../common/img/languages/"+filename+".png";
+		}
 
 		// Called by MDM to add a language to the list of languages
 		function mdm_add_language(language_name, language_code) {
 
-			var filename = language_code.toLowerCase();
-			filename = filename.replace(".utf-8", "");
-			bits = filename.split("_");
-			if (bits.length == 2) {
-				filename = bits[1];																	
-			}
 			var li = document.createElement('li');			
 				
 			var link = document.createElement('a');	
@@ -182,7 +204,7 @@
 
 			var picture = document.createElement('img');
 				picture.setAttribute('class', "language-picture");
-				picture.setAttribute('src', "../common/img/languages/"+filename+".png");
+				picture.setAttribute('src', mdm_get_language_flag_filepath(language_code));
 				picture.setAttribute('onerror', "this.src='../common/img/languages/generic.png';");
 											
 			var name_div = document.createTextNode(language_name);				
@@ -196,13 +218,7 @@
 		}	
 
 		function mdm_set_current_language(language_name, language_code)	{
-			var filename = language_code.toLowerCase();
-			filename = filename.replace(".utf-8", "");
-			bits = filename.split("_");
-			if (bits.length == 2) {
-				filename = bits[1];																	
-			}
-			document.getElementById("current_language_flag").src = "../common/img/languages/"+filename+".png";			
+			document.getElementById("current_language_flag").src = mdm_get_language_flag_filepath(language_code);			
 			document.getElementById("current_language_flag").title = language_name;
 		}
 		

--- a/mint-mdm-themes-html/usr/share/mdm/html-themes/Synergy/index.html
+++ b/mint-mdm-themes-html/usr/share/mdm/html-themes/Synergy/index.html
@@ -236,13 +236,36 @@
 			document.getElementById("current_session_picture").title = session_name;
 		}
 
-		// Called by MDM to add a language to the list of languages
-		function mdm_add_language(language_name, language_code) {
-
+		// Called by MDM to get the full path of a language flag file
+		function mdm_get_language_flag_filepath(language_code) {
 			var filename = language_code.toLowerCase();
 			filename = filename.replace(".utf-8", "");
-			bits = filename.split("_");
-			if (bits.length == 2) filename = bits[1];
+			var bits = filename.split("_");
+
+			// Check for minority languages that have a flag.
+			// For example: Catalan's language code can be ca or ca_es or ca_fr, Welsh's cy or cy_gb...
+			if (filename === "ca" || bits[0] === "ca") {
+				filename = "_Catalonia";
+			} else if (filename === "cy" || bits[0] === "cy") {
+				filename = "_Wales";
+			} else if (filename === "eu" || bits[0] === "eu") {
+				filename = "_Basque Country";
+			} else if (filename === "gd" || bits[0] === "gd") {
+				filename = "_Scotland";
+			} else if (filename === "gl" || bits[0] === "gl") {
+				filename = "_Galicia";
+			} else if (filename === "sco" || bits[0] === "sco") {
+				filename = "_Scotland";
+			// Use the country code part of the language code (if it's available). For example: en_AU -> au.
+			} else if (bits.length === 2) {
+				filename = bits[1];
+			}
+
+			return "../common/img/languages/"+filename+".png";
+		}
+
+		// Called by MDM to add a language to the list of languages
+		function mdm_add_language(language_name, language_code) {
 
 			var li = document.createElement('li');	
 				
@@ -251,7 +274,7 @@
 				link.addEventListener('click', toggleLangBox, true);
 
 			var picture = document.createElement('img');
-				picture.setAttribute('src', "img/languages/"+filename+".png");
+				picture.setAttribute('src', mdm_get_language_flag_filepath(language_code));
 				picture.setAttribute('onerror', "this.src='img/languages/generic.png';");
 											
 			var name_div = document.createElement('div');
@@ -266,13 +289,7 @@
 		}	
 
 		function mdm_set_current_language(language_name, language_code)	{
-			var filename = language_code.toLowerCase();
-			filename = filename.replace(".utf-8", "");
-			bits = filename.split("_");
-			if (bits.length == 2) {
-				filename = bits[1];											
-			}
-			document.getElementById("current_lang").src = "img/languages/"+filename+".png";			
+			document.getElementById("current_lang").src = mdm_get_language_flag_filepath(language_code);			
 			document.getElementById("current_lang").title = language_name;  
 		}
 		

--- a/mint-mdm-themes-html/usr/share/mdm/html-themes/Synergy/index.html
+++ b/mint-mdm-themes-html/usr/share/mdm/html-themes/Synergy/index.html
@@ -270,7 +270,7 @@
 			var li = document.createElement('li');	
 				
 			var link = document.createElement('a');	
-				link.setAttribute('href', "javascript:alert('LANGUAGE###"+language_code+"')");
+				link.setAttribute('href', "javascript:alert('LANGUAGE###"+language_code+"');mdm_set_current_language('"+language_name+"','"+language_code+"');");
 				link.addEventListener('click', toggleLangBox, true);
 
 			var picture = document.createElement('img');

--- a/mint-mdm-themes-html/usr/share/mdm/html-themes/Zukitwo-Circle/index.html
+++ b/mint-mdm-themes-html/usr/share/mdm/html-themes/Zukitwo-Circle/index.html
@@ -240,10 +240,10 @@
 		function mdm_add_language(language_name, language_code) {
 
 			var link1 = document.createElement('a');	
-				link1.setAttribute('href', "javascript:alert('LANGUAGE###"+language_code+"')");
+				link1.setAttribute('href', "javascript:alert('LANGUAGE###"+language_code+"');mdm_set_current_language('"+language_name+"','"+language_code+"');");
 
 			var link2 = document.createElement('a');	
-				link2.setAttribute('href', "javascript:alert('LANGUAGE###"+language_code+"')");
+				link2.setAttribute('href', "javascript:alert('LANGUAGE###"+language_code+"');mdm_set_current_language('"+language_name+"','"+language_code+"');");
 
 			var picture = document.createElement('img');
 				picture.setAttribute('class', "language-picture");

--- a/mint-mdm-themes-html/usr/share/mdm/html-themes/Zukitwo-Circle/index.html
+++ b/mint-mdm-themes-html/usr/share/mdm/html-themes/Zukitwo-Circle/index.html
@@ -208,15 +208,36 @@
 			$('#current_session_picture').popover('hide');
 		}
 
-		// Called by MDM to add a language to the list of languages
-		function mdm_add_language(language_name, language_code) {
-
+		// Called by MDM to get the full path of a language flag file
+		function mdm_get_language_flag_filepath(language_code) {
 			var filename = language_code.toLowerCase();
 			filename = filename.replace(".utf-8", "");
-			bits = filename.split("_");
-			if (bits.length == 2) {
+			var bits = filename.split("_");
+
+			// Check for minority languages that have a flag.
+			// For example: Catalan's language code can be ca or ca_es or ca_fr, Welsh's cy or cy_gb...
+			if (filename === "ca" || bits[0] === "ca") {
+				filename = "_Catalonia";
+			} else if (filename === "cy" || bits[0] === "cy") {
+				filename = "_Wales";
+			} else if (filename === "eu" || bits[0] === "eu") {
+				filename = "_Basque Country";
+			} else if (filename === "gd" || bits[0] === "gd") {
+				filename = "_Scotland";
+			} else if (filename === "gl" || bits[0] === "gl") {
+				filename = "_Galicia";
+			} else if (filename === "sco" || bits[0] === "sco") {
+				filename = "_Scotland";
+			// Use the country code part of the language code (if it's available). For example: en_AU -> au.
+			} else if (bits.length === 2) {
 				filename = bits[1];
 			}
+
+			return "../common/img/languages/"+filename+".png";
+		}
+
+		// Called by MDM to add a language to the list of languages
+		function mdm_add_language(language_name, language_code) {
 
 			var link1 = document.createElement('a');	
 				link1.setAttribute('href', "javascript:alert('LANGUAGE###"+language_code+"')");
@@ -226,7 +247,7 @@
 
 			var picture = document.createElement('img');
 				picture.setAttribute('class', "language-picture");
-				picture.setAttribute('src', "../common/img/languages/"+filename+".png");
+				picture.setAttribute('src', mdm_get_language_flag_filepath(language_code));
 				picture.setAttribute('onerror', "this.src='../common/img/languages/generic.png';");
 				picture.setAttribute('title', language_name);				
 											
@@ -249,13 +270,7 @@
 		}
 
 		function mdm_set_current_language(language_name, language_code)	{
-			var filename = language_code.toLowerCase();
-			filename = filename.replace(".utf-8", "");
-			bits = filename.split("_");
-			if (bits.length == 2) {
-				filename = bits[1];
-			}
-			document.getElementById("current_language_flag").src = "img/language.svg";
+			document.getElementById("current_language_flag").src = mdm_get_language_flag_filepath(language_code);
 			document.getElementById("current_language_flag").title = language_name;
 			document.getElementById("current_language_flag").width = 16;
 		}

--- a/mint-mdm-themes-html/usr/share/mdm/html-themes/Zukitwo-Transparent/index.html
+++ b/mint-mdm-themes-html/usr/share/mdm/html-themes/Zukitwo-Transparent/index.html
@@ -208,15 +208,37 @@
 			$('#current_session_picture').popover('hide');
 		}
 
-		// Called by MDM to add a language to the list of languages
-		function mdm_add_language(language_name, language_code) {
-
+		
+		// Called by MDM to get the full path of a language flag file
+		function mdm_get_language_flag_filepath(language_code) {
 			var filename = language_code.toLowerCase();
 			filename = filename.replace(".utf-8", "");
-			bits = filename.split("_");
-			if (bits.length == 2) {
+			var bits = filename.split("_");
+
+			// Check for minority languages that have a flag.
+			// For example: Catalan's language code can be ca or ca_es or ca_fr, Welsh's cy or cy_gb...
+			if (filename === "ca" || bits[0] === "ca") {
+				filename = "_Catalonia";
+			} else if (filename === "cy" || bits[0] === "cy") {
+				filename = "_Wales";
+			} else if (filename === "eu" || bits[0] === "eu") {
+				filename = "_Basque Country";
+			} else if (filename === "gd" || bits[0] === "gd") {
+				filename = "_Scotland";
+			} else if (filename === "gl" || bits[0] === "gl") {
+				filename = "_Galicia";
+			} else if (filename === "sco" || bits[0] === "sco") {
+				filename = "_Scotland";
+			// Use the country code part of the language code (if it's available). For example: en_AU -> au.
+			} else if (bits.length === 2) {
 				filename = bits[1];
 			}
+
+			return "../common/img/languages/"+filename+".png";
+		}
+
+		// Called by MDM to add a language to the list of languages
+		function mdm_add_language(language_name, language_code) {
 
 			var link1 = document.createElement('a');	
 				link1.setAttribute('href', "javascript:alert('LANGUAGE###"+language_code+"')");
@@ -226,7 +248,7 @@
 
 			var picture = document.createElement('img');
 				picture.setAttribute('class', "language-picture");
-				picture.setAttribute('src', "../common/img/languages/"+filename+".png");
+				picture.setAttribute('src', mdm_get_language_flag_filepath(language_code));
 				picture.setAttribute('onerror', "this.src='../common/img/languages/generic.png';");
 				picture.setAttribute('title', language_name);				
 											
@@ -249,13 +271,7 @@
 		}
 
 		function mdm_set_current_language(language_name, language_code)	{
-			var filename = language_code.toLowerCase();
-			filename = filename.replace(".utf-8", "");
-			bits = filename.split("_");
-			if (bits.length == 2) {
-				filename = bits[1];
-			}
-			document.getElementById("current_language_flag").src = "img/language.svg";
+			document.getElementById("current_language_flag").src = mdm_get_language_flag_filepath(language_code);
 			document.getElementById("current_language_flag").title = language_name;
 			document.getElementById("current_language_flag").width = 16;
 		}

--- a/mint-mdm-themes-html/usr/share/mdm/html-themes/Zukitwo-Transparent/index.html
+++ b/mint-mdm-themes-html/usr/share/mdm/html-themes/Zukitwo-Transparent/index.html
@@ -241,10 +241,10 @@
 		function mdm_add_language(language_name, language_code) {
 
 			var link1 = document.createElement('a');	
-				link1.setAttribute('href', "javascript:alert('LANGUAGE###"+language_code+"')");
+				link1.setAttribute('href', "javascript:alert('LANGUAGE###"+language_code+"');mdm_set_current_language('"+language_name+"','"+language_code+"');");
 
 			var link2 = document.createElement('a');	
-				link2.setAttribute('href', "javascript:alert('LANGUAGE###"+language_code+"')");
+				link2.setAttribute('href', "javascript:alert('LANGUAGE###"+language_code+"');mdm_set_current_language('"+language_name+"','"+language_code+"');");
 
 			var picture = document.createElement('img');
 				picture.setAttribute('class', "language-picture");

--- a/mint-mdm-themes-html/usr/share/mdm/html-themes/Zukitwo/index.html
+++ b/mint-mdm-themes-html/usr/share/mdm/html-themes/Zukitwo/index.html
@@ -240,10 +240,10 @@
 		function mdm_add_language(language_name, language_code) {
 
 			var link1 = document.createElement('a');	
-				link1.setAttribute('href', "javascript:alert('LANGUAGE###"+language_code+"')");
+				link1.setAttribute('href', "javascript:alert('LANGUAGE###"+language_code+"');mdm_set_current_language('"+language_name+"','"+language_code+"');");
 
 			var link2 = document.createElement('a');	
-				link2.setAttribute('href', "javascript:alert('LANGUAGE###"+language_code+"')");
+				link2.setAttribute('href', "javascript:alert('LANGUAGE###"+language_code+"');mdm_set_current_language('"+language_name+"','"+language_code+"');");
 
 			var picture = document.createElement('img');
 				picture.setAttribute('class', "language-picture");

--- a/mint-mdm-themes-html/usr/share/mdm/html-themes/Zukitwo/index.html
+++ b/mint-mdm-themes-html/usr/share/mdm/html-themes/Zukitwo/index.html
@@ -208,15 +208,36 @@
 			$('#current_session_picture').popover('hide');
 		}
 
-		// Called by MDM to add a language to the list of languages
-		function mdm_add_language(language_name, language_code) {
-
+		// Called by MDM to get the full path of a language flag file
+		function mdm_get_language_flag_filepath(language_code) {
 			var filename = language_code.toLowerCase();
 			filename = filename.replace(".utf-8", "");
-			bits = filename.split("_");
-			if (bits.length == 2) {
+			var bits = filename.split("_");
+
+			// Check for minority languages that have a flag.
+			// For example: Catalan's language code can be ca or ca_es or ca_fr, Welsh's cy or cy_gb...
+			if (filename === "ca" || bits[0] === "ca") {
+				filename = "_Catalonia";
+			} else if (filename === "cy" || bits[0] === "cy") {
+				filename = "_Wales";
+			} else if (filename === "eu" || bits[0] === "eu") {
+				filename = "_Basque Country";
+			} else if (filename === "gd" || bits[0] === "gd") {
+				filename = "_Scotland";
+			} else if (filename === "gl" || bits[0] === "gl") {
+				filename = "_Galicia";
+			} else if (filename === "sco" || bits[0] === "sco") {
+				filename = "_Scotland";
+			// Use the country code part of the language code (if it's available). For example: en_AU -> au.
+			} else if (bits.length === 2) {
 				filename = bits[1];
 			}
+
+			return "../common/img/languages/"+filename+".png";
+		}
+
+		// Called by MDM to add a language to the list of languages
+		function mdm_add_language(language_name, language_code) {
 
 			var link1 = document.createElement('a');	
 				link1.setAttribute('href', "javascript:alert('LANGUAGE###"+language_code+"')");
@@ -226,7 +247,7 @@
 
 			var picture = document.createElement('img');
 				picture.setAttribute('class', "language-picture");
-				picture.setAttribute('src', "../common/img/languages/"+filename+".png");
+				picture.setAttribute('src', mdm_get_language_flag_filepath(language_code));
 				picture.setAttribute('onerror', "this.src='../common/img/languages/generic.png';");
 				picture.setAttribute('title', language_name);				
 											
@@ -249,13 +270,7 @@
 		}
 
 		function mdm_set_current_language(language_name, language_code)	{
-			var filename = language_code.toLowerCase();
-			filename = filename.replace(".utf-8", "");
-			bits = filename.split("_");
-			if (bits.length == 2) {
-				filename = bits[1];
-			}
-			document.getElementById("current_language_flag").src = "img/language.svg";
+			document.getElementById("current_language_flag").src = mdm_get_language_flag_filepath(language_code);
 			document.getElementById("current_language_flag").title = language_name;
 			document.getElementById("current_language_flag").width = 16;
 		}


### PR DESCRIPTION
Hi,

there are complaints in the growing community of Basque speaking Linux Mint users about the use of the Spanish/French flags in the login screen.

I found that there are some flags that can be used for minority languages in this repository in the folder mint-mdm-themes-html/usr/share/mdm/html-themes/common/img/languages/, so I thought why don't we use them? I think that many people would feel more comfortable that way.

Catalan (ca) -> "_Catalonia.png"
Welsh (cy) -> "_Wales.png"
Basque (eu) -> "_Basque Country.png"
Scottish Gaelic (gd) -> "_Scotland.png" 
Galician (gl) -> "_Galicia.png"
Scots (sco) -> "_Scotland.png"

Best regards