### PR TITLE
Disable user-select for non-input elements

### DIFF
--- a/mint-mdm-themes-html/usr/share/mdm/html-themes/Mint-X/theme.css
+++ b/mint-mdm-themes-html/usr/share/mdm/html-themes/Mint-X/theme.css
@@ -28,6 +28,11 @@ body {
 
 * {
 	z-index: 2;
+	-webkit-user-select: none;  /* overridden for input */
+}
+
+input {
+	-webkit-user-select: text;
 }
 
 a {


### PR DESCRIPTION
This patch prevents the following unattractive output from accidentally clicking and dragging on the login screen:

![User selection of DOM elements](http://imgur.com/KuUx44C.png)

Tested in a fresh VM and on a real install, both of Linux Mint 17.2.

I'm only patching Mint-X because it's the default theme.