### PR TITLE
Change error text color to orange in the Mint-X theme

### DIFF
--- a/mint-mdm-themes-html/usr/share/mdm/html-themes/Mint-X/theme.css
+++ b/mint-mdm-themes-html/usr/share/mdm/html-themes/Mint-X/theme.css
@@ -400,7 +400,7 @@ a:focus {
     padding: 8px 8px 8px 8px;
     margin-top: 20px;
     margin-right: 20px;
-    color: red;
+    color: orange;
 }
 
 #timed {


### PR DESCRIPTION
As a color blind person, red text against a dark background is near impossible to see. Changing the error text color to orange gives better contrast and is easier to see.