### PR TITLE
Hide gecos if same as username

### DIFF
--- a/mint-mdm-themes-html/usr/share/mdm/html-themes/Mint-X/mdm.js
+++ b/mint-mdm-themes-html/usr/share/mdm/html-themes/Mint-X/mdm.js
@@ -123,7 +123,12 @@ function mdm_add_user(username, gecos, status, avatar) {
 
     var font_gecos = document.createElement('font');
         font_gecos.setAttribute('class', "font_gecos");
-        font_gecos.innerHTML = " " + gecos;
+        if (gecos != username) {
+            font_gecos.innerHTML = " " + gecos;
+	}
+        else {
+            font_gecos.innerHTML = " ";
+	}
 
     div.appendChild(font_username);
     div.appendChild(font_gecos);


### PR DESCRIPTION
username and geos are the same by default and some (most of) users doesn't change geos and are troubled by the display of twice the username. So here i hide the geos if it's the same as the username